### PR TITLE
Add ESP32 sample implementation

### DIFF
--- a/sample-implementations/esp32/sensirion_i2c_esp32_config.h
+++ b/sample-implementations/esp32/sensirion_i2c_esp32_config.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023, Sensirion AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Sensirion AG nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SENSIRION_I2C_ESP32_CONFIG_H
+#define SENSIRION_I2C_ESP32_CONFIG_H
+
+#include <i2cdev.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int esp_err_t;
+
+struct esp32_i2c_config {
+    uint32_t freq;
+    uint8_t addr;
+    i2c_port_t port;
+    gpio_num_t sda;
+    gpio_num_t scl;
+    bool sda_pullup;
+    bool scl_pullup;
+};
+
+extern esp_err_t sensirion_i2c_config_esp32(struct esp32_i2c_config* cfg);
+extern esp_err_t sensirion_i2c_esp32_ok(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SENSIRION_I2C_ESP32_CONFIG_H */

--- a/sample-implementations/esp32/sensirion_i2c_hal.c
+++ b/sample-implementations/esp32/sensirion_i2c_hal.c
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2023, Sensirion AG
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Sensirion AG nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sensirion_i2c_hal.h"
+#include "sensirion_common.h"
+#include "sensirion_config.h"
+
+#include <esp_log.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <string.h>
+
+#include "sensirion_i2c_esp32_config.h"
+
+static const char* TAG = "sensirion_i2c_hal";
+
+#define SLEEP_MS(x) \
+    vTaskDelay(((x) + portTICK_PERIOD_MS - 1) / portTICK_PERIOD_MS)
+#define CHECK(x)                \
+    do {                        \
+        esp_err_t __;           \
+        if ((__ = x) != ESP_OK) \
+            return __;          \
+    } while (0)
+#define CHECK_ARG(VAL)                  \
+    do {                                \
+        if (!(VAL))                     \
+            return ESP_ERR_INVALID_ARG; \
+    } while (0)
+#define UNUSED_PARAM(x) (void)x
+
+static i2c_dev_t dev = {0};
+static struct esp32_i2c_config i2c_cfg = {0};
+static esp_err_t i2c_ok = ESP_OK;
+
+/*
+ * INSTRUCTIONS
+ * ============
+ *
+ * Implement all functions where they are marked as IMPLEMENT.
+ * Follow the function specification in the comments.
+ */
+
+/**
+ * Select the current i2c bus by index.
+ * All following i2c operations will be directed at that bus.
+ *
+ * THE IMPLEMENTATION IS OPTIONAL ON SINGLE-BUS SETUPS (all sensors on the same
+ * bus)
+ *
+ * @param bus_idx   Bus index to select
+ * @returns         0 on success, an error code otherwise
+ */
+int16_t sensirion_i2c_hal_select_bus(uint8_t bus_idx) {
+    /* TODO:IMPLEMENT or leave empty if all sensors are located on one single
+     * bus
+     */
+    return NOT_IMPLEMENTED_ERROR;
+}
+
+esp_err_t sensirion_i2c_config_esp32(struct esp32_i2c_config* cfg) {
+    if (cfg != NULL) {
+        memcpy(&i2c_cfg, cfg, sizeof(*cfg));
+        return ESP_OK;
+    } else {
+        return ESP_FAIL;
+    }
+}
+
+esp_err_t sensirion_i2c_esp32_ok(void) {
+    return i2c_ok;
+}
+
+/**
+ * Initialize all hard- and software components that are needed for the I2C
+ * communication.
+ */
+void sensirion_i2c_hal_init(void) {
+    memset(&dev, 0, sizeof(i2c_dev_t));
+    // dev.addr = addr;
+    dev.port = i2c_cfg.port;
+    dev.cfg.mode = I2C_MODE_MASTER;
+    dev.cfg.sda_io_num = i2c_cfg.sda;
+    dev.cfg.scl_io_num = i2c_cfg.scl;
+    dev.cfg.sda_pullup_en = i2c_cfg.sda_pullup;
+    dev.cfg.scl_pullup_en = i2c_cfg.scl_pullup;
+#if HELPER_TARGET_IS_ESP32
+    dev.cfg.master.clk_speed = i2c_cfg.freq;
+#endif
+
+    esp_err_t err = i2c_dev_create_mutex(&dev);
+    if (err == ESP_OK) {
+        ESP_LOGI(
+            TAG,
+            "Sensirion I2C initialized. Address: 0x%x Port: %d SDA: %d SCL: %d",
+            i2c_cfg.addr, i2c_cfg.port, i2c_cfg.sda, i2c_cfg.scl);
+    } else {
+        ESP_LOGE(TAG,
+                 "Error initializing Sensirion I2C! Address: 0x%x Port: %d "
+                 "SDA: %d SCL: %d",
+                 i2c_cfg.addr, i2c_cfg.port, i2c_cfg.sda, i2c_cfg.scl);
+    }
+
+    i2c_ok = err;
+}
+
+/**
+ * Release all resources initialized by sensirion_i2c_hal_init().
+ */
+void sensirion_i2c_hal_free(void) {
+}
+
+/**
+ * Execute one read transaction on the I2C bus, reading a given number of bytes.
+ * If the device does not acknowledge the read command, an error shall be
+ * returned.
+ *
+ * @param address 7-bit I2C address to read from
+ * @param data    pointer to the buffer where the data is to be stored
+ * @param count   number of bytes to read from I2C and store in the buffer
+ * @returns 0 on success, error code otherwise
+ */
+int8_t sensirion_i2c_hal_read(uint8_t address, uint8_t* data, uint16_t count) {
+    ESP_LOGI(TAG, "sensirion_i2c_hal_read: len: %d", count);
+    dev.addr = address;
+    I2C_DEV_TAKE_MUTEX(&dev);
+    I2C_DEV_CHECK(&dev, i2c_dev_read(&dev, NULL, 0, data, count));
+    I2C_DEV_GIVE_MUTEX(&dev);
+    ESP_LOGI(TAG, "READ OK");
+    return (int8_t)ESP_OK;
+}
+
+/**
+ * Execute one write transaction on the I2C bus, sending a given number of
+ * bytes. The bytes in the supplied buffer must be sent to the given address. If
+ * the slave device does not acknowledge any of the bytes, an error shall be
+ * returned.
+ *
+ * @param address 7-bit I2C address to write to
+ * @param data    pointer to the buffer containing the data to write
+ * @param count   number of bytes to read from the buffer and send over I2C
+ * @returns 0 on success, error code otherwise
+ */
+int8_t sensirion_i2c_hal_write(uint8_t address, const uint8_t* data,
+                               uint16_t count) {
+    ESP_LOGI(TAG, "sensirion_i2c_hal_write: len: %d", count);
+    dev.addr = address;
+    I2C_DEV_TAKE_MUTEX(&dev);
+    I2C_DEV_CHECK(&dev, i2c_dev_write(&dev, NULL, 0, data, count));
+    I2C_DEV_GIVE_MUTEX(&dev);
+    ESP_LOGI(TAG, "WRITE OK");
+    return (int8_t)ESP_OK;
+}
+
+/**
+ * Sleep for a given number of microseconds. The function should delay the
+ * execution for at least the given time, but may also sleep longer.
+ *
+ * Despite the unit, a <10 millisecond precision is sufficient.
+ *
+ * @param useconds the sleep time in microseconds
+ */
+void sensirion_i2c_hal_sleep_usec(uint32_t useconds) {
+    ESP_LOGI(TAG, "sensirion_i2c_hal_sleep: %d usec", useconds);
+    SLEEP_MS(useconds / 1000);
+}


### PR DESCRIPTION
This PR adds a sample implementation for the ESP32 platform, built on the ESP-IDF SDK.

Example usage:
```
#include "sensirion_i2c_esp32_config.h"

struct esp32_i2c_config cfg;
cfg.freq = I2C_FREQ;
cfg.addr = I2C_ADDR_SEN5X;
cfg.port = I2C_NUM_0;
cfg.sda = I2C_SDA_GPIO_PIN;
cfg.scl = I2C_SCL_GPIO_PIN;
cfg.sda_pullup = true;
cfg.scl_pullup = true;

ESP_ERROR_CHECK(sensirion_i2c_config_esp32(&cfg));

sensirion_i2c_hal_init();

ESP_ERROR_CHECK(sensirion_i2c_esp32_ok());

ESP_ERROR_CHECK((esp_err_t)sen5x_device_reset());

unsigned char sen5x_name[32];
sen5x_get_product_name(&sen5x_name[0], 32);
unsigned char sen5x_serial[32];
sen5x_get_serial_number(&sen5x_serial[0], 32);
```
Tested with ESP-IDF v4.4.4 using the Sensirion SEN50 and SEN55.